### PR TITLE
Show site url instead of cryptic name

### DIFF
--- a/src/menu-ui.ts
+++ b/src/menu-ui.ts
@@ -136,7 +136,7 @@ export default class UI {
 
   private getSitesSubmenu(sites: NetlifySite[]): MenuItemConstructorOptions[] {
     return sites.map(
-      ({ name, id }): MenuItemConstructorOptions => ({
+      ({ id, url }): MenuItemConstructorOptions => ({
         checked: this.settings.currentSiteId === id,
         click: async () => {
           this.saveSetting('currentSiteId', id);
@@ -148,7 +148,7 @@ export default class UI {
             }
           });
         },
-        label: name,
+        label: `${url.replace(/https?:\/\//, '')}`,
         type: 'radio'
       })
     );


### PR DESCRIPTION
<img width="571" alt="screenshot 2019-01-12 16 44 48" src="https://user-images.githubusercontent.com/962099/51075878-6443b400-1689-11e9-8aee-80675a84010f.png">

@ChristopherBiscardi I switched the site menu to show Url instead of the meaningless name. :)

Hope that works fine!

Edited: haha that's a bad example. :D 

<img width="359" alt="screenshot 2019-01-12 16 46 37" src="https://user-images.githubusercontent.com/962099/51075893-a240d800-1689-11e9-9844-e3183a79e1d2.png">

👆🏻 for custom domains it shows them now too.